### PR TITLE
Copy header information

### DIFF
--- a/brainExtractionRegistration.pl
+++ b/brainExtractionRegistration.pl
@@ -341,7 +341,7 @@ system("${antsPath}antsApplyTransforms -d 3 -r $headImage -i $templateBrainMask 
 
 system("${antsPath}ThresholdImage 3 $brainMaskFromReg $brainMaskFromReg 0.5 Inf");
 
-copy($brainMaskFromReg, "${outputRoot}BrainMask.nii.gz");
+system("${antsPath}CopyImageHeaderInformation $inputHead $brainMaskFromReg ${outputRoot}BrainMask.nii.gz 1 1 1");
 
 # If we have priors, warp those too
 if (scalar(@segPriors) > 0) {
@@ -352,6 +352,8 @@ if (scalar(@segPriors) > 0) {
 	my $priorClass = $1;
 
 	system("${antsPath}antsApplyTransforms -d 3 -i $prior -r $headImage -t [${warpPrefix}0GenericAffine.mat, 1] -t ${warpPrefix}1InverseWarp.nii.gz -n Gaussian -o ${outputRoot}SegPrior${priorClass}.nii.gz --float $useFloatPrecision --verbose");
+
+        system("${antsPath}CopyImageHeaderInformation $inputHead ${outputRoot}SegPrior${priorClass}.nii.gz ${outputRoot}SegPrior${priorClass}.nii.gz 1 1 1");
     }
 
 }

--- a/brainExtractionSegmentation.pl
+++ b/brainExtractionSegmentation.pl
@@ -215,11 +215,11 @@ my $brainMaskDilated = "${tmpDir}/brainMaskDilated.nii.gz";
 
 # Dilate the initial mask, this forms the maximal possible mask
 system("${antsPath}ImageMath 3 $brainMaskDilated MD $initialBrainMaskPad $dilationRadius");
+system("${antsPath}CopyImageHeaderInformation $initialBrainMask $brainMaskDilated $brainMaskDilated 1 1 1");
 
 if ($doN4) {
     # Bright voxels within initial mask can sometimes cause N4 problems, but don't want to compress actual contrast
-    # After initial brain masking, most of the brightest voxels should be gone
-    # system("${antsPath}ImageMath 3 $headImage TruncateImageIntensity $headImage 0.0 0.999 256 $brainMaskDilated");
+    # After initial brain masking, most of the brightest voxels should be outside the mask
     system("${antsPath}N4BiasFieldCorrection -d 3 -i $headImage -s 3 -c [50x50x50x50,0.0000001] -b [200] -x $brainMaskDilated -o $headImage --verbose 1");
 }
 
@@ -332,7 +332,8 @@ system("${antsPath}ImageMath 3 $extractedBrain m $headImage $brainMaskPad");
 system("${antsPath}ImageMath 3 ${outputRoot}BrainMask.nii.gz PadImage $brainMaskPad -${padVoxels}");
 system("${antsPath}ImageMath 3 ${outputRoot}ExtractedBrain.nii.gz PadImage $extractedBrain -${padVoxels}");
 
-
+system("${antsPath}CopyImageHeaderInformation $inputHead ${outputRoot}BrainMask.nii.gz ${outputRoot}BrainMask.nii.gz 1 1 1");
+system("${antsPath}CopyImageHeaderInformation $inputHead ${outputRoot}ExtractedBrain.nii.gz ${outputRoot}ExtractedBrain.nii.gz 1 1 1");
 
 
 # cleanup

--- a/brainExtractionSegmentation.pl
+++ b/brainExtractionSegmentation.pl
@@ -215,7 +215,6 @@ my $brainMaskDilated = "${tmpDir}/brainMaskDilated.nii.gz";
 
 # Dilate the initial mask, this forms the maximal possible mask
 system("${antsPath}ImageMath 3 $brainMaskDilated MD $initialBrainMaskPad $dilationRadius");
-system("${antsPath}CopyImageHeaderInformation $initialBrainMask $brainMaskDilated $brainMaskDilated 1 1 1");
 
 if ($doN4) {
     # Bright voxels within initial mask can sometimes cause N4 problems, but don't want to compress actual contrast


### PR DESCRIPTION
Call CopyImageHeaderInformation to try to keep the output brain mask in the same physical space as the input image.